### PR TITLE
Add orgchart virtual resource

### DIFF
--- a/ckanext/datasetsnippets/helpers.py
+++ b/ckanext/datasetsnippets/helpers.py
@@ -262,3 +262,18 @@ def wfs_endpoint_for_dataset(dataset_dict: dict) -> str:
                 if resource.get('url'):
                     return resource['url']
     return None
+
+def orgchart_endpoint_for_dataset(dataset_dict: dict) -> str:
+    '''Returns the orgchart endpoint for a dataset. The dataset is considered
+    an orgchart dataset if it has the tag `_organigramm`. The endpoint is the
+    URL of the first resource with `format` == `JSON`. Returns `None` if the
+    dataset is not an orgchart dataset, or doesn't have a JSON resource with
+    a URL.'''
+    tags = [tag.get('name') for tag in dataset_dict.get('tags', [])]
+    if '_organigramm' not in tags:
+        return None
+    for resource in dataset_dict['resources']:
+        if resource.get('format') and resource['format'].upper() == "JSON":
+            if resource.get('url'):
+                return resource['url']
+    return None

--- a/ckanext/datasetsnippets/plugin.py
+++ b/ckanext/datasetsnippets/plugin.py
@@ -68,6 +68,7 @@ class DatasetsnippetsPlugin(plugins.SingletonPlugin):
             'berlin_pagination_url_for_page': theme_helpers.pagination_url_for_page ,
             'berlin_unique_resource_formats': theme_helpers.unique_resource_formats ,
             'berlin_wfs_endpoint_for_dataset': theme_helpers.wfs_endpoint_for_dataset ,
+            'berlin_orgchart_endpoint_for_dataset': theme_helpers.orgchart_endpoint_for_dataset ,
         }
 
     # IAuthFunctions

--- a/ckanext/datasetsnippets/templates/datasetsnippets/snippets/resources_list.html
+++ b/ckanext/datasetsnippets/templates/datasetsnippets/snippets/resources_list.html
@@ -36,6 +36,29 @@ Example:
                 paneltype="colored" %}
             {% endif %}
           {% endblock wfs_explorer %}
+          {% block orgchart_viewer %}
+            {% set endpoint = h.berlin_orgchart_endpoint_for_dataset(package) %}
+            {% if endpoint %}
+              {% snippet 'datasetsnippets/snippets/resource_item.html',
+                package=package,
+                resource = {
+                  "name": "Organigramm ansehen",
+                  "format": "HTML",
+                  "description": "Organigramm ansehen und in verschiedenen Formaten herunterladen: RDF, PDF, PNG, JSON, barrierefreies HTML und barrierefreies PDF.",
+                  "url": "https://organigramme.odis-berlin.de/?dataurl=" + endpoint + "&readonly"
+                },
+                paneltype="colored" %}
+              {% snippet 'datasetsnippets/snippets/resource_item.html',
+                package=package,
+                resource = {
+                  "name": '<i class="icon bicon bicon-universal-access" aria-hidden="true"></i> Barrierefreie Organigramm-Ansicht'|safe,
+                  "format": "HTML",
+                  "description": "Darstellung des Organigramms als barrierefreie, für Screenreader optimierte Listenansicht.",
+                  "url": "https://organigramme.odis-berlin.de/?dataurl=" + endpoint + "&readonly&format=html-accessible"
+                },
+                paneltype="colored" %}
+            {% endif %}
+          {% endblock orgchart_viewer %}
         {% endblock resource_list_inner %}
       {% else %}
         <p class="empty">{{ _('This dataset has no data') }}</p>

--- a/ckanext/datasetsnippets/tests/test_helpers.py
+++ b/ckanext/datasetsnippets/tests/test_helpers.py
@@ -313,3 +313,103 @@ class TestHelpers(object):
     def test_wfs_endpoint_for_dataset(self, data: dict):
         '''Test to see if the correct values is returned.'''
         assert dshelpers.wfs_endpoint_for_dataset(data['dataset_dict']) == data['expected']
+
+    @pytest.mark.parametrize('data', [
+        {
+            # a typical orgchart dataset: tag `_organigramm` and a JSON resource
+            'dataset_dict': {
+                'tags': [
+                    {'name': 'organigramm'},
+                    {'name': '_organigramm'},
+                ],
+                'resources': [
+                    {
+                        'format': 'PDF',
+                        'name': 'Beschreibung',
+                        'url': 'https://example.org/orgchart.pdf',
+                    },
+                    {
+                        'format': 'JSON',
+                        'name': 'Organigramm-Daten',
+                        'url': 'https://example.org/orgchart.json',
+                    },
+                ],
+            },
+            'expected': 'https://example.org/orgchart.json',
+        },
+        {
+            # tag `_organigramm` missing, even though there is a JSON resource
+            'dataset_dict': {
+                'tags': [
+                    {'name': 'organigramm'},
+                ],
+                'resources': [
+                    {
+                        'format': 'JSON',
+                        'name': 'Organigramm-Daten',
+                        'url': 'https://example.org/orgchart.json',
+                    },
+                ],
+            },
+            'expected': None,
+        },
+        {
+            # tag `_organigramm` is present, but no JSON resource
+            'dataset_dict': {
+                'tags': [
+                    {'name': '_organigramm'},
+                ],
+                'resources': [
+                    {
+                        'format': 'PDF',
+                        'name': 'Beschreibung',
+                        'url': 'https://example.org/orgchart.pdf',
+                    },
+                ],
+            },
+            'expected': None,
+        },
+        {
+            # tag `_organigramm` is present, JSON resource is present but
+            # has no URL
+            'dataset_dict': {
+                'tags': [
+                    {'name': '_organigramm'},
+                ],
+                'resources': [
+                    {
+                        'format': 'JSON',
+                        'name': 'Organigramm-Daten',
+                    },
+                ],
+            },
+            'expected': None,
+        },
+        {
+            # lowercase `json` should still match
+            'dataset_dict': {
+                'tags': [
+                    {'name': '_organigramm'},
+                ],
+                'resources': [
+                    {
+                        'format': 'json',
+                        'name': 'Organigramm-Daten',
+                        'url': 'https://example.org/orgchart.json',
+                    },
+                ],
+            },
+            'expected': 'https://example.org/orgchart.json',
+        },
+        {
+            # no tags at all, no resources
+            'dataset_dict': {
+                'tags': [],
+                'resources': [],
+            },
+            'expected': None,
+        },
+    ])
+    def test_orgchart_endpoint_for_dataset(self, data: dict):
+        '''Test to see if the correct values is returned for orgchart datasets.'''
+        assert dshelpers.orgchart_endpoint_for_dataset(data['dataset_dict']) == data['expected']


### PR DESCRIPTION
## Summary
Adds a new virtual resource type that links datasets representing organisational charts to the [organigramme.odis-berlin.de](https://organigramme.odis-berlin.de/) viewer, following the same pattern as the existing WFS-Explorer virtual resource (see docs/virtual_resource.md).

### Detection rule
A dataset is treated as an orgchart dataset when both are true:
- the dataset has the tag _organigramm
- at least one of its resources has format == "JSON" (case-insensitive) and a non-empty url
The URL of the first matching JSON resource is used as the dataurl= parameter.

### Rendered output
When the rule matches, two extra panels appear at the bottom of the resources list:

Organigramm ansehen:	https://organigramme.odis-berlin.de/?dataurl=<endpoint>&readonly
Barrierefreie Organigramm-Ansicht:	https://organigramme.odis-berlin.de/?dataurl=<endpoint>&readonly&format=html-accessible

The second panel's name contains an `<i class="icon bicon bicon-universal-access">` element; it's rendered with Jinja's |safe so the icon is shown rather than escaped.

### Changes
- ckanext/datasetsnippets/helpers.py — new orgchart_endpoint_for_dataset() helper.
- ckanext/datasetsnippets/plugin.py — registers berlin_orgchart_endpoint_for_dataset in get_helpers().
- ckanext/datasetsnippets/templates/datasetsnippets/snippets/resources_list.html — new orgchart_viewer block next to the existing wfs_explorer block.
- ckanext/datasetsnippets/tests/test_helpers.py — six parametrised test cases covering the helper.

### Tests
A unit test with various configurations for good and bad input based on the wfs tests.

### Open question (follow-up)
The _organigramm tag is currently a magic string with no mechanism to surface it in the dataset-creation form. Three options for follow-up, in increasing scope:
1. Rely on CKAN's tag autocomplete after the first dataset is tagged (no code change).
2. Add a controlled vocabulary in ckanext-berlin_dataset_schema.